### PR TITLE
Add KSPAssembly information and bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+copyToKSP.bat
 
 # Build results
 
@@ -167,3 +168,6 @@ Source/KSP_Data
 
 # Index of names in source code
 tags
+
+# Visual Studio 2022 project files
+.vs/

--- a/GameData/Astrogator/Astrogator-Changelog.cfg
+++ b/GameData/Astrogator/Astrogator-Changelog.cfg
@@ -7,6 +7,17 @@ KERBALCHANGELOG
 	showChangelog = True
 	VERSION
 	{
+		version = 0.10.4
+		versionName = Salted Beef
+		versionKSP = 1.12
+		CHANGE
+		{
+			change = Include Assembly version information
+			type = Add
+		}
+	}
+	VERSION
+	{
 		version = 0.10.3
 		versionName = Alderson Point
 		versionKSP = 1.12

--- a/GameData/Astrogator/Astrogator.version
+++ b/GameData/Astrogator/Astrogator.version
@@ -10,7 +10,7 @@
 	"VERSION": {
 		"MAJOR": 0,
 		"MINOR": 10,
-		"PATCH": 3
+		"PATCH": 4
 	},
 	"KSP_VERSION_MIN": {
 		"MAJOR": 1,

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("HebaruSan")]
 [assembly: AssemblyProduct("Astrogator")]
-[assembly: AssemblyCopyright("Copyright © 2017-2021")]
+[assembly: AssemblyCopyright("Copyright © 2017-2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.10.3.0")]
-[assembly: AssemblyFileVersion("0.10.3.0")]
+[assembly: AssemblyVersion("0.10.4.0")]
+[assembly: AssemblyFileVersion("0.10.4.0")]
+[assembly: KSPAssembly("Astrogator", 0, 10)]


### PR DESCRIPTION
This is to align with the kOS-Astrogator requirements to add dependency to Astrogator.